### PR TITLE
chore: update renovate, deps, and some repo meta

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text eol=lf
+*.png binary

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Swellaby
+Copyright (c) 2020 Swellaby
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/extension/package.json
+++ b/extension/package.json
@@ -19,22 +19,22 @@
     "azure-devops-extension-sdk": "2.0.11"
   },
   "devDependencies": {
-    "@commitlint/cli": "9.0.1",
-    "@commitlint/config-conventional": "9.0.1",
-    "@types/jest": "26.0.3",
-    "copy-webpack-plugin": "6.0.2",
-    "fixpack": "3.0.6",
-    "html-webpack-plugin": "4.3.0",
-    "husky": "4.2.5",
-    "jest": "26.1.0",
-    "jest-junit": "11.0.1",
-    "lint-staged": "10.2.11",
-    "tfx-cli": "0.8.1",
-    "ts-jest": "26.1.1",
-    "ts-loader": "7.0.5",
-    "typescript": "3.9.5",
-    "webpack": "4.43.0",
-    "webpack-cli": "3.3.12"
+    "@commitlint/cli": "^9.1.1",
+    "@commitlint/config-conventional": "^9.1.1",
+    "@types/jest": "^26.0.9",
+    "copy-webpack-plugin": "^6.0.3",
+    "fixpack": "^3.0.6",
+    "html-webpack-plugin": "^4.3.0",
+    "husky": "^4.2.5",
+    "jest": "^26.2.2",
+    "jest-junit": "^11.1.0",
+    "lint-staged": "^10.2.11",
+    "tfx-cli": "^0.8.1",
+    "ts-jest": "^26.1.4",
+    "ts-loader": "^8.0.2",
+    "typescript": "^3.9.7",
+    "webpack": "^4.44.1",
+    "webpack-cli": "^3.3.12"
   },
   "engines": {
     "node": ">=12"

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "config:base"
+    "@swellaby"
   ]
 }


### PR DESCRIPTION
* Update renovate config to use our shared config module (renovate will only bump on major version updates for dependencies)
* Update license to correct year, and add gitattributes file
* Bump all dev deps for extension to latest to close open renovate PRs